### PR TITLE
remove vgpu-scheduler grpc code

### DIFF
--- a/charts/vgpu/templates/device-plugin/daemonsetmlu.yaml
+++ b/charts/vgpu/templates/device-plugin/daemonsetmlu.yaml
@@ -44,7 +44,6 @@ spec:
             - --virtualization-num=10 #  virtualization number for each MLU, used only in sriov mode or env-share mode
             - --mlulink-policy=best-effort # MLULink topology policy: best-effort, guaranteed or restricted, used only in topology-aware mode
             - --cnmon-path=/usr/bin/cnmon # host machine cnmon path, must be absolute path. comment out this line to avoid mounting cnmon.
-            - --scheduler-endpoint={{ printf "%s:%d" ( include "4pd-vgpu.scheduler" . ) ( int .Values.scheduler.service.grpcPort ) }}
             #- --enable-console #uncomment to enable UART console device(/dev/ttyMS) in container
             #- --disable-health-check #uncomment to disable health check
             #- --enable-device-type #uncomment to enable device registration with type info

--- a/charts/vgpu/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/vgpu/templates/device-plugin/daemonsetnvidia.yaml
@@ -46,7 +46,6 @@ spec:
             - nvidia-device-plugin
             - --resource-name={{ .Values.resourceName }}
             - --mig-strategy={{ .Values.devicePlugin.migStrategy }}
-            - --scheduler-endpoint={{ printf "%s:%d" ( include "4pd-vgpu.scheduler" . ) ( int .Values.scheduler.service.grpcPort ) }}
             - --device-memory-scaling={{ .Values.devicePlugin.deviceMemoryScaling }}
             - --device-split-count={{ .Values.devicePlugin.deviceSplitCount }}
             - --disable-core-limit={{ .Values.devicePlugin.disablecorelimit }}

--- a/charts/vgpu/templates/scheduler/deployment.yaml
+++ b/charts/vgpu/templates/scheduler/deployment.yaml
@@ -60,7 +60,6 @@ spec:
             - --resource-mem-percentage={{ .Values.resourceMemPercentage }}
             - --resource-priority={{ .Values.resourcePriority }}
             - --http_bind=0.0.0.0:443
-            - --grpc_bind=0.0.0.0:1080
             - --cert_file=/tls/tls.crt
             - --key_file=/tls/tls.key
             - --scheduler-name={{ .Values.schedulerName }}
@@ -72,9 +71,6 @@ spec:
           ports:
             - name: http
               containerPort: 443
-              protocol: TCP
-            - name: grpc
-              containerPort: 1080
               protocol: TCP
           volumeMounts:
             - name: tls-config

--- a/charts/vgpu/templates/scheduler/service.yaml
+++ b/charts/vgpu/templates/scheduler/service.yaml
@@ -18,10 +18,6 @@ spec:
       port: {{ .Values.scheduler.service.httpPort }}
       targetPort: 443
       protocol: TCP
-    - name: grpc
-      port: {{ .Values.scheduler.service.grpcPort }}
-      targetPort: 1080
-      protocol: TCP
     - name: monitor
       port: {{ .Values.scheduler.service.monitorPort }}
       targetPort: 9395

--- a/charts/vgpu/values.yaml
+++ b/charts/vgpu/values.yaml
@@ -63,7 +63,6 @@ scheduler:
   service:
     httpPort: 443
     monitorPort: 31993
-    grpcPort: 1080
     labels: {}
     annotations: {}
 

--- a/cmd/device-plugin/nvidia/main.go
+++ b/cmd/device-plugin/nvidia/main.go
@@ -75,8 +75,6 @@ func init() {
 	rootCmd.Flags().UintVar(&config.DeviceSplitCount, "device-split-count", 2, "the number for NVIDIA device split")
 	rootCmd.Flags().Float64Var(&config.DeviceMemoryScaling, "device-memory-scaling", 1.0, "the ratio for NVIDIA device memory scaling")
 	rootCmd.Flags().Float64Var(&config.DeviceCoresScaling, "device-cores-scaling", 1.0, "the ratio for NVIDIA device cores scaling")
-	rootCmd.Flags().StringVar(&config.SchedulerEndpoint, "scheduler-endpoint", "127.0.0.1:9090", "scheduler extender endpoint")
-	rootCmd.Flags().IntVar(&config.SchedulerTimeout, "scheduler-timeout", 10, "scheduler connection timeout")
 	rootCmd.Flags().StringVar(&config.NodeName, "node-name", viper.GetString("node-name"), "node name")
 	rootCmd.Flags().BoolVar(&config.DisableCoreLimit, "disable-core-limit", false, "If set, the core utilization limit will be ignored")
 

--- a/pkg/device-plugin/config/config.go
+++ b/pkg/device-plugin/config/config.go
@@ -20,8 +20,6 @@ var (
 	DeviceSplitCount    uint
 	DeviceMemoryScaling float64
 	DeviceCoresScaling  float64
-	SchedulerEndpoint   string
-	SchedulerTimeout    int
 	NodeName            string
 	RuntimeSocketFlag   string
 	DisableCoreLimit    bool

--- a/pkg/device-plugin/mlu/options.go
+++ b/pkg/device-plugin/mlu/options.go
@@ -32,7 +32,6 @@ type Options struct {
 	EnableConsole      bool   `long:"enable-console" description:"enable UART console device(/dev/ttyMS) in container"`
 	EnableDeviceType   bool   `long:"enable-device-type" description:"enable device registration with type info"`
 	CnmonPath          string `long:"cnmon-path" description:"host cnmon path"`
-	SchedulerEndpoint  string `long:"scheduler-endpoint" description:"endpoint for device plugin to register"`
 	SocketPath         string `long:"socket-path" description:"socket path for communication between deviceplugin and container runtime"`
 }
 
@@ -59,7 +58,6 @@ func ParseFlags() Options {
 	}
 	config.DeviceSplitCount = options.VirtualizationNum
 	config.RuntimeSocketFlag = options.SocketPath
-	config.SchedulerEndpoint = options.SchedulerEndpoint
 	log.Printf("Parsed options: %v\n", options)
 	return options
 }

--- a/pkg/device-plugin/nvidiadevice/register.go
+++ b/pkg/device-plugin/nvidiadevice/register.go
@@ -17,7 +17,6 @@
 package nvidiadevice
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 	"4pd.io/k8s-vgpu/pkg/api"
 	"4pd.io/k8s-vgpu/pkg/device-plugin/config"
 	"4pd.io/k8s-vgpu/pkg/util"
-	"google.golang.org/grpc"
 )
 
 type DevListFunc func() []*Device
@@ -83,62 +81,6 @@ func (r *DeviceRegister) apiDevices() *[]*api.DeviceInfo {
 	return &res
 }
 
-func (r *DeviceRegister) Register(ctx context.Context) error {
-	conn, err := grpc.DialContext(
-		ctx,
-		config.SchedulerEndpoint,
-		grpc.WithInsecure(),
-		grpc.WithBlock(),
-		//grpc.WithConnectParams(grpc.ConnectParams{MinConnectTimeout: 3}),
-	)
-	if err != nil {
-		return fmt.Errorf("connect scheduler error, %v", err)
-	}
-	client := api.NewDeviceServiceClient(conn)
-	register, err := client.Register(ctx)
-	if err != nil {
-		klog.Errorf("register error %v", err)
-		err = fmt.Errorf("client register error, %v", err)
-		return err
-	}
-	req := api.RegisterRequest{Node: config.NodeName, Devices: *r.apiDevices()}
-	err = register.Send(&req)
-	if err != nil {
-		klog.Errorf("register send error, %v", err)
-		return err
-	}
-	klog.V(3).Infof("register info %v", req.String())
-	closeCh := make(chan struct{})
-	go func() {
-		reply := api.RegisterReply{}
-		err := register.RecvMsg(reply)
-		if err != nil {
-			klog.Errorf("register recv error, %v", err)
-		} else {
-			klog.Errorf("register recv closed")
-		}
-		closeCh <- struct{}{}
-	}()
-	for {
-		select {
-		case <-r.unhealthy:
-			err = register.Send(&api.RegisterRequest{
-				Node:    config.NodeName,
-				Devices: *r.apiDevices(),
-			})
-			if err != nil {
-				klog.Errorf("register send error, %v", err)
-				return err
-			}
-			klog.V(3).Infof("register info %v", req.String())
-		case <-closeCh:
-			return fmt.Errorf("register server closed")
-		case <-r.stopCh:
-			return nil
-		}
-	}
-}
-
 func (r *DeviceRegister) RegistrInAnnotation() error {
 	devices := r.apiDevices()
 	annos := make(map[string]string)
@@ -160,20 +102,14 @@ func (r *DeviceRegister) RegistrInAnnotation() error {
 }
 
 func (r *DeviceRegister) WatchAndRegister() {
-	//ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	//defer cancel()
 	klog.Infof("into WatchAndRegister")
-	//ctx := context.Background()
 	for {
 		err := r.RegistrInAnnotation()
-		//err := r.Register(ctx)
 		if err != nil {
 			klog.Errorf("register error, %v", err)
 			time.Sleep(time.Second * 5)
 		} else {
 			time.Sleep(time.Second * 30)
-			//klog.Infof("register stopped")
-			//break
 		}
 	}
 }

--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -18,7 +18,6 @@ package config
 
 var (
 	HttpBind      string
-	GrpcBind      string
 	SchedulerName string
 	DefaultMem    int32
 	DefaultCores  int32


### PR DESCRIPTION
The address and timeout parameters can remove in program and helm chart, as vgpu-scheduler is no longer used grpc to communicate with deviceplugin.