### PR TITLE
feature: support custom webhook url and generate it's certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ You can now execute `nvidia-smi` command in the container and see the difference
 
 Click [here](docs/examples/nvidia/)
 
+### Scheduler Webhook Service NodePort
+
+Default schedulerPort is 31998, other values can be set using `--set deivcePlugin.service.schedulerPort` during installation.
+
 ### Monitoring vGPU status
 
 Monitoring is automatically enabled after installation. You can get vGPU status of a node by visiting 

--- a/charts/vgpu/templates/scheduler/job-patch/job-createSecret.yaml
+++ b/charts/vgpu/templates/scheduler/job-patch/job-createSecret.yaml
@@ -40,7 +40,11 @@ spec:
             - create
             - --cert-name=tls.crt
             - --key-name=tls.key
+            {{- if .Values.scheduler.customWebhook.enabled }}
+            - --host={{ printf "%s.%s.svc,127.0.0.1,%s" (include "4pd-vgpu.scheduler" .) .Release.Namespace .Values.scheduler.customWebhook.host}}
+            {{- else }}
             - --host={{ printf "%s.%s.svc,127.0.0.1" (include "4pd-vgpu.scheduler" .) .Release.Namespace }}
+            {{- end }}
             - --namespace={{ .Release.Namespace }}
             - --secret-name={{ include "4pd-vgpu.scheduler.tls" . }}
       restartPolicy: OnFailure

--- a/charts/vgpu/templates/scheduler/service.yaml
+++ b/charts/vgpu/templates/scheduler/service.yaml
@@ -17,6 +17,7 @@ spec:
     - name: http
       port: {{ .Values.scheduler.service.httpPort }}
       targetPort: 443
+      nodePort: {{ .Values.scheduler.service.schedulerPort }}
       protocol: TCP
     - name: monitor
       port: {{ .Values.scheduler.service.monitorPort }}

--- a/charts/vgpu/templates/scheduler/webhook.yaml
+++ b/charts/vgpu/templates/scheduler/webhook.yaml
@@ -6,11 +6,15 @@ webhooks:
   - admissionReviewVersions:
     - v1beta1
     clientConfig:
+      {{- if .Values.scheduler.customWebhook.enabled }}
+      url: https://{{ .Values.scheduler.customWebhook.host}}:{{.Values.scheduler.customWebhook.port}}{{.Values.scheduler.customWebhook.path}}
+      {{- else }}
       service:
         name: {{ include "4pd-vgpu.scheduler" . }}
         namespace: {{ .Release.Namespace }}
         path: /webhook
         port: {{ .Values.scheduler.service.httpPort }}
+      {{- end }}
     failurePolicy: Fail
     matchPolicy: Equivalent
     name: vgpu.4pd.io

--- a/charts/vgpu/values.yaml
+++ b/charts/vgpu/values.yaml
@@ -54,8 +54,8 @@ scheduler:
     enabled: false
     # must be an endpoint using https.
     # should generate host certs here
-    host: 127.0.0.1 # hostname or ip
-    port: 443
+    host: 127.0.0.1 # hostname or ip, can be your node'IP if you want to use https://<nodeIP>:<schedulerPort>/<path>
+    port: 31998
     path: /webhook
   patch:
     image: docker.io/jettech/kube-webhook-certgen:v1.5.2
@@ -69,6 +69,7 @@ scheduler:
 
   service:
     httpPort: 443
+    schedulerPort: 31998
     monitorPort: 31993
     labels: {}
     annotations: {}

--- a/charts/vgpu/values.yaml
+++ b/charts/vgpu/values.yaml
@@ -50,6 +50,13 @@ scheduler:
     gpu: "on"
   tolerations: []
   #serviceAccountName: "4pd-vgpu-scheduler-sa"
+  customWebhook:
+    enabled: false
+    # must be an endpoint using https.
+    # should generate host certs here
+    host: 127.0.0.1 # hostname or ip
+    port: 443
+    path: /webhook
   patch:
     image: docker.io/jettech/kube-webhook-certgen:v1.5.2
     imageNew: liangjw/kube-webhook-certgen:v1.1.1


### PR DESCRIPTION
Some time we should custom webhook address instead of using  Service. for example,  k8s on k8s or vclusters.  we can't use  service discovery to let  work node  know the real scheduler's  addr.

This pr make project support this scene. custom webhook url and fixed schedulerPort to 31998