### PR TITLE
add host network flag for NodePort exposure bug when load balancer in…

### DIFF
--- a/charts/vgpu/templates/device-plugin/daemonsetmlu.yaml
+++ b/charts/vgpu/templates/device-plugin/daemonsetmlu.yaml
@@ -30,6 +30,7 @@ spec:
       serviceAccountName: {{ include "4pd-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
       hostPID: true
+      hostNetwork: true
       containers:
         - name: cambricon-device-plugin-ctr
           image: {{ .Values.devicePlugin.image }}:{{ .Values.version }}

--- a/charts/vgpu/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/vgpu/templates/device-plugin/daemonsetnvidia.yaml
@@ -34,6 +34,7 @@ spec:
       serviceAccountName: {{ include "4pd-vgpu.device-plugin" . }}
       priorityClassName: system-node-critical
       hostPID: true
+      hostNetwork: true
       containers:
         - name: device-plugin
           image: {{ .Values.devicePlugin.image }}:{{ .Values.version }}


### PR DESCRIPTION
在k8s集群的NodePort模式下，如果将31992端口暴露，在k8s集群也打开了负载均衡时，会出现http://ip:31992汇报的是别的机器的gpu使用信息的问题。而如果时候用hostNetwork: true 则通过http://ip:9394可以解决这个问题。