### PR TITLE
Fix klog verbose not working

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -24,6 +24,7 @@ import (
 	"4pd.io/k8s-vgpu/pkg/scheduler"
 	"4pd.io/k8s-vgpu/pkg/scheduler/config"
 	"4pd.io/k8s-vgpu/pkg/scheduler/routes"
+	"4pd.io/k8s-vgpu/pkg/util"
 	"github.com/julienschmidt/httprouter"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -56,6 +57,7 @@ func init() {
 	rootCmd.Flags().Int32Var(&config.DefaultCores, "default-cores", 0, "default gpu core percentage to allocate")
 	rootCmd.PersistentFlags().AddGoFlagSet(device.GlobalFlagSet())
 	rootCmd.AddCommand(version.VersionCmd)
+	rootCmd.Flags().AddGoFlagSet(util.InitKlogFlags())
 }
 
 func start() {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"strconv"
 	"strings"
@@ -290,4 +291,12 @@ func PatchPodAnnotations(pod *v1.Pod, annotations map[string]string) error {
 		}*/
 
 	return err
+}
+
+func InitKlogFlags() *flag.FlagSet {
+	// Init log flags
+	flagset := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(flagset)
+
+	return flagset
 }


### PR DESCRIPTION
klog verbose log level not working properly

before, no matter how we adjust the log level, the log will not be output.

https://github.com/4paradigm/k8s-vgpu-scheduler/blob/master/pkg/scheduler/scheduler.go#L136
```golang
klog.V(5).Infoln("Scheduler into RegisterFromNodeAnnotations")
```


klog flags need to be added to rootCmd flags
