### PR TITLE
support mutiple gpu card numa

### DIFF
--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register_test.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021 peizhaoyou <peizhaoyou@4paradigm.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package plugin
+
+import "testing"
+
+func Test_parseNvidiaNumaInfo(t *testing.T) {
+	type args struct {
+		idx           int
+		nvidiaTopoStr string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "single Tesla P4 NUMA",
+			args: args{
+				idx: 0,
+				nvidiaTopoStr: `GPU0	CPU Affinity	NUMA Affinity	GPU NUMA ID
+GPU0	 X 	0-7		N/A		N/A
+
+Legend:
+
+	X    = Self
+	SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
+	NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
+	PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
+	PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
+	PIX  = Connection traversing at most a single PCIe bridge
+	NV#  = Connection traversing a bonded set of # NVLinks
+					`,
+			},
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name: "two Tesla P4 NUMA topo with index 0",
+			args: args{
+				idx: 0,
+				nvidiaTopoStr: `GPU0	GPU1	CPU Affinity	NUMA Affinity
+GPU0	 X 	PHB	0-31		N/A
+GPU1	PHB	 X 	0-31		N/A
+
+Legend:
+
+	X    = Self
+	SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
+	NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
+	PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
+	PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
+	PIX  = Connection traversing at most a single PCIe bridge
+	NV#  = Connection traversing a bonded set of # NVLinks
+					`,
+			},
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name: "two Tesla P4 NUMA topo with index 1",
+			args: args{
+				idx: 1,
+				nvidiaTopoStr: `GPU0	GPU1	CPU Affinity	NUMA Affinity
+GPU0	 X 	PHB	0-31		N/A
+GPU1	PHB	 X 	0-31		N/A
+
+Legend:
+
+	X    = Self
+	SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
+	NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
+	PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
+	PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
+	PIX  = Connection traversing at most a single PCIe bridge
+	NV#  = Connection traversing a bonded set of # NVLinks
+					`,
+			},
+			want:    0,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNvidiaNumaInfo(tt.args.idx, tt.args.nvidiaTopoStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseNvidiaNumaInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseNvidiaNumaInfo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Failed to obtain numa information, the error message is as follows
```bash
E1214 10:59:54.986452    2829 register.go:86] "failed to get numa information" err="strconv.Atoi: parsing \"N/A\": invalid syntax" idx=0
```

/kind feature

## This PR is associated with two issues

###  Single Tesla P4, fix NUMA information acquisition exception

Single Tesla P4， nvidia-smi topo info 
```bash
root@controller-node-1:/# nvidia-smi topo -m
	GPU0	CPU Affinity	NUMA Affinity	GPU NUMA ID
GPU0	 X 	0-7		N/A		N/A

Legend:

  X    = Self
  SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
  NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
  PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
  PIX  = Connection traversing at most a single PCIe bridge
  NV#  = Connection traversing a bonded set of # NVLinks
```
`NUMA Affinity = N/A`, This scenario is not processed and `strconv.Atoi` is executed directly and an exception error is reported.

### In multi-card scenarios, `NUMA Affinity` information is inaccurate and wrong information is assigned.

Two Tesla P4， nvidia-smi topo info 
```bash
root@ubuntu:~# nvidia-smi topo -m
	GPU0	GPU1	CPU Affinity	NUMA Affinity
GPU0	 X 	PHB	0-31		N/A
GPU1	PHB	 X 	0-31		N/A

Legend:

  X    = Self
  SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
  NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
  PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
  PIX  = Connection traversing at most a single PCIe bridge
  NV#  = Connection traversing a bonded set of # NVLinks
```
It was found that in the single-card scenario, the order of the headers changed. 

-  single-card scenario `NUMA Affinity` is in the fourth column
-  multi-card scenario `NUMA Affinity` is in the last column (as the number of cards increases, the columns increase)

Therefore, the logic is adjusted to: first obtain the column index where `NUMA Affinity` is located, and then obtain the corresponding value of the card based on the index value.
