### PR TITLE
clean: fix node name typo

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -162,7 +162,7 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	ctrvGPUdeviceAllocateCorePercentageDesc := prometheus.NewDesc(
 		"vGPUCorePercentage",
 		"vGPU core allocated from a container",
-		[]string{"namespace", "nmodename", "podname", "containeridx", "deviceuuid"}, nil,
+		[]string{"namespace", "nodename", "podname", "containeridx", "deviceuuid"}, nil,
 	)
 	schedpods, _ := sher.GetScheduledPods()
 	for _, val := range schedpods {


### PR DESCRIPTION
修复metrics typo