### PR TITLE
fix the problem that two metrics services are not unified to namespace

### DIFF
--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -152,17 +152,17 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	ctrvGPUDeviceAllocatedDesc := prometheus.NewDesc(
 		"vGPUPodsDeviceAllocated",
 		"vGPU Allocated from pods",
-		[]string{"namespace", "nodename", "podname", "containeridx", "deviceuuid", "deviceusedcore"}, nil,
+		[]string{"podnamespace", "nodename", "podname", "containeridx", "deviceuuid", "deviceusedcore"}, nil,
 	)
 	ctrvGPUdeviceAllocatedMemoryPercentageDesc := prometheus.NewDesc(
 		"vGPUMemoryPercentage",
 		"vGPU memory percentage allocated from a container",
-		[]string{"namespace", "nodename", "podname", "containeridx", "deviceuuid"}, nil,
+		[]string{"podnamespace", "nodename", "podname", "containeridx", "deviceuuid"}, nil,
 	)
 	ctrvGPUdeviceAllocateCorePercentageDesc := prometheus.NewDesc(
 		"vGPUCorePercentage",
 		"vGPU core allocated from a container",
-		[]string{"namespace", "nmodename", "podname", "containeridx", "deviceuuid"}, nil,
+		[]string{"podnamespace", "nmodename", "podname", "containeridx", "deviceuuid"}, nil,
 	)
 	schedpods, _ := sher.GetScheduledPods()
 	for _, val := range schedpods {


### PR DESCRIPTION
修复两个metrics 对pod namespace label名称定义不统一的问题