### PR TITLE
enhance schedule process logs

### DIFF
--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -83,21 +83,21 @@ func checkType(annos map[string]string, d util.DeviceUsage, n util.ContainerDevi
 	return false, false
 }
 
-func fitInCertainDevice(node *NodeUsage, request util.ContainerDeviceRequest, annos map[string]string) (bool, []util.ContainerDevice) {
+func fitInCertainDevice(node *NodeUsage, request util.ContainerDeviceRequest, annos map[string]string, pod *v1.Pod) (bool, []util.ContainerDevice) {
 	k := request
 	originReq := k.Nums
 	prevnuma := -1
-	klog.Infoln("Allocating device for container request", k)
+	klog.InfoS("Allocating device for container request", "pod", klog.KObj(pod), "card request", k)
 	tmpDevs := []util.ContainerDevice{}
 	for i := len(node.Devices) - 1; i >= 0; i-- {
-		klog.InfoS("scoring pod", "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i, "device", node.Devices[i].Id)
+		klog.InfoS("scoring pod", "pod", klog.KObj(pod), "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i, "device", node.Devices[i].Id)
 		found, numa := checkType(annos, *node.Devices[i], k)
 		if !found {
-			klog.Infoln("card type mismatch,continueing...", node.Devices[i].Type, k.Type)
+			klog.InfoS("card type mismatch,continueing...", "pod", klog.KObj(pod), node.Devices[i].Type, k.Type)
 			continue
 		}
 		if numa && prevnuma != node.Devices[i].Numa {
-			klog.Infoln("Numa not fit, resotoreing....k.nums=", k.Nums, "numa=", numa, ":", prevnuma, ":", node.Devices[i].Numa)
+			klog.InfoS("Numa not fit, resotoreing", "pod", klog.KObj(pod), "k.nums", k.Nums, "numa", numa, "prevnuma", prevnuma, "device numa", node.Devices[i].Numa)
 			k.Nums = originReq
 			prevnuma = node.Devices[i].Numa
 			tmpDevs = []util.ContainerDevice{}
@@ -108,7 +108,7 @@ func fitInCertainDevice(node *NodeUsage, request util.ContainerDeviceRequest, an
 			continue
 		}
 		if k.Coresreq > 100 {
-			klog.Errorf("core limit can't exceed 100")
+			klog.ErrorS(nil, "core limit can't exceed 100", "pod", klog.KObj(pod))
 			return false, tmpDevs
 		}
 		if k.Memreq > 0 {
@@ -119,21 +119,25 @@ func fitInCertainDevice(node *NodeUsage, request util.ContainerDeviceRequest, an
 			memreq = node.Devices[i].Totalmem * k.MemPercentagereq / 100
 		}
 		if node.Devices[i].Totalmem-node.Devices[i].Usedmem < memreq {
+			klog.V(5).InfoS("card Insufficient remaining memory", "pod", klog.KObj(pod), "device index", i, "device", node.Devices[i].Id, "device total memory", node.Devices[i].Totalmem, "device used memory", node.Devices[i].Usedmem, "request memory", memreq)
 			continue
 		}
 		if node.Devices[i].Totalcore-node.Devices[i].Usedcores < k.Coresreq {
+			klog.V(5).InfoS("card Insufficient remaining cores", "pod", klog.KObj(pod), "device index", i, "device", node.Devices[i].Id, "device total core", node.Devices[i].Totalcore, "device used core", node.Devices[i].Usedcores, "request cores", k.Coresreq)
 			continue
 		}
 		// Coresreq=100 indicates it want this card exclusively
 		if node.Devices[i].Totalcore == 100 && k.Coresreq == 100 && node.Devices[i].Used > 0 {
+			klog.V(5).InfoS("the container wants exclusive access to an entire card, but the card is already in use", "pod", klog.KObj(pod), "device index", i, "device", node.Devices[i].Id, "used", node.Devices[i].Used)
 			continue
 		}
 		// You can't allocate core=0 job to an already full GPU
 		if node.Devices[i].Totalcore != 0 && node.Devices[i].Usedcores == node.Devices[i].Totalcore && k.Coresreq == 0 {
+			klog.V(5).InfoS("can't allocate core=0 job to an already full GPU", "pod", klog.KObj(pod), "device index", i, "device", node.Devices[i].Id)
 			continue
 		}
 		if k.Nums > 0 {
-			klog.Infoln("device", node.Devices[i].Id, "first fitted")
+			klog.InfoS("first fitted", "pod", klog.KObj(pod), "device", node.Devices[i].Id)
 			k.Nums--
 			tmpDevs = append(tmpDevs, util.ContainerDevice{
 				Idx:       i,
@@ -144,14 +148,14 @@ func fitInCertainDevice(node *NodeUsage, request util.ContainerDeviceRequest, an
 			})
 		}
 		if k.Nums == 0 {
-			klog.Infoln("device allocate success")
+			klog.InfoS("device allocate success", "pod", klog.KObj(pod), "allocate device", tmpDevs)
 			return true, tmpDevs
 		}
 	}
 	return false, tmpDevs
 }
 
-func fitInDevices(node *NodeUsage, requests []util.ContainerDeviceRequest, annos map[string]string) (bool, float32, []util.ContainerDevice) {
+func fitInDevices(node *NodeUsage, requests []util.ContainerDeviceRequest, annos map[string]string, pod *v1.Pod) (bool, float32, []util.ContainerDevice) {
 	devs := []util.ContainerDevice{}
 	total := int32(0)
 	free := int32(0)
@@ -160,10 +164,11 @@ func fitInDevices(node *NodeUsage, requests []util.ContainerDeviceRequest, annos
 	for _, k := range requests {
 		sums += int(k.Nums)
 		if int(k.Nums) > len(node.Devices) {
+			klog.InfoS("request devices nums cannot exceed the total number of devices on the node.", "pod", klog.KObj(pod), "request devices nums", k.Nums, "node device nums", len(node.Devices))
 			return false, 0, devs
 		}
 		sort.Sort(node.Devices)
-		fit, tmpDevs := fitInCertainDevice(node, k, annos)
+		fit, tmpDevs := fitInCertainDevice(node, k, annos, pod)
 		if fit {
 			for _, val := range tmpDevs {
 				total += node.Devices[val.Idx].Count
@@ -196,14 +201,14 @@ func calcScore(nodes *map[string]*NodeUsage, errMap *map[string]string, nums [][
 				score.devices = append(score.devices, util.ContainerDevices{})
 				continue
 			}
-			klog.V(5).InfoS("fitInDevices", "pod name", task.Name, "pod namespace", task.Namespace, "node", nodeID)
-			fit, nodescore, devs := fitInDevices(node, n, annos)
+			klog.V(5).InfoS("fitInDevices", "pod", klog.KObj(task), "node", nodeID)
+			fit, nodescore, devs := fitInDevices(node, n, annos, task)
 			if fit {
 				score.devices = append(score.devices, devs)
-				klog.InfoS("calcScore:pod fit node score results", "pod name", task.Name, "pod namespace", task.Namespace, "node", nodeID, "score", nodescore)
+				klog.InfoS("calcScore:pod fit node score results", "pod", klog.KObj(task), "node", nodeID, "score", nodescore)
 				score.score += nodescore
 			} else {
-				klog.InfoS("calcScore:node not fit pod", "pod name", task.Name, "pod namespace", task.Namespace, "node", nodeID)
+				klog.InfoS("calcScore:node not fit pod", "pod", klog.KObj(task), "node", nodeID)
 				break
 			}
 		}


### PR DESCRIPTION
The current scheduling process is relatively black-box. Once scheduling fails, users have no way of knowing the specific reasons. At the same time, the logic of the scheduling selection card and the pod association are not enough. Therefore, try to output more logs during the scheduling process to facilitate user troubleshooting.

Previous scheduling log information
```bash
I0110 09:29:05.389816     207 scheduler.go:347] "begin schedule filter" pod="vgpu-test-dc87df5b4-6ndkz" uuid="f94a3a21-a348-4ca3-af74-cbda013eab0b" namespaces="default"
I0110 09:29:05.389891     207 scheduler.go:288] usage: pod vgpu-test-dc87df5b4-24r9c assigned tesla [[{0 GPU-e290caca-2f0c-9582-acab-67a142b61ffa NVIDIA 1000 100}]]67a142b61ffa","Index":0,"Used":1,"Count":10,"Usedmem":1000,"Totalmem":7680,"Totalcore":100,"Usedcores":100,"Numa":0,"Type":"NVIDIA-Tesla P4","Health":true}
I0110 09:29:05.389943     207 score.go:199] "fitInDevices" pod name="vgpu-test-dc87df5b4-6ndkz" pod namespace="default" node="tesla"
I0110 09:29:05.389952     207 score.go:90] Allocating device for container request {1 NVIDIA 1000 101 100}
I0110 09:29:05.389968     207 score.go:93] "scoring pod" Memreq=1000 MemPercentagereq=101 Coresreq=100 Nums=1 device index=0 device="GPU-e290caca-2f0c-9582-acab-67a142b61ffa"
I0110 09:29:05.389983     207 score.go:206] "calcScore:node not fit pod" pod name="vgpu-test-dc87df5b4-6ndkz" pod namespace="default" node="tesla"
```
At this time, we don’t know which pod to select the card for, and we don’t know the specific information about the card selection failure.

The effect after modification is as follows
succeed schedule logs
```bash

I0110 09:18:41.847887     175 scheduler.go:347] "begin schedule filter" pod="vgpu-test-2-67957884fc-ch9tp" uuid="ea1f7d6a-00f5-40d0-9728-c4165066ff10" namespaces="default"
I0110 09:18:41.847996     175 scheduler.go:288] usage: pod vgpu-test-2-67957884fc-9nnhh assigned tesla [[{0 GPU-e290caca-2f0c-9582-acab-67a142b61ffa NVIDIA 1000 0}]]
I0110 09:18:41.848094     175 score.go:204] "fitInDevices" pod="default/vgpu-test-2-67957884fc-ch9tp" node="tesla"
I0110 09:18:41.848116     175 score.go:90] "Allocating device for container request" pod="default/vgpu-test-2-67957884fc-ch9tp" card request={"Nums":1,"Type":"NVIDIA","Memreq":1000,"MemPercentagereq":101,"Coresreq":0}
I0110 09:18:41.848131     175 score.go:93] "scoring pod" pod="default/vgpu-test-2-67957884fc-ch9tp" Memreq=1000 MemPercentagereq=101 Coresreq=0 Nums=1 device index=0 device="GPU-e290caca-2f0c-9582-acab-67a142b61ffa"
I0110 09:18:41.848144     175 score.go:140] "first fitted" pod="default/vgpu-test-2-67957884fc-ch9tp" device="GPU-e290caca-2f0c-9582-acab-67a142b61ffa"
I0110 09:18:41.848187     175 score.go:151] "device allocate success" pod="default/vgpu-test-2-67957884fc-ch9tp" allocate device=[{"Idx":0,"UUID":"GPU-e290caca-2f0c-9582-acab-67a142b61ffa","Type":"NVIDIA","Usedmem":1000,"Usedcores":0}]
I0110 09:18:41.848210     175 score.go:208] "calcScore:pod fit node score results" pod="default/vgpu-test-2-67957884fc-ch9tp" node="tesla" score=1.1111112
I0110 09:18:41.848217     175 scheduler.go:383] schedule default/vgpu-test-2-67957884fc-ch9tp to tesla [[{0 GPU-e290caca-2f0c-9582-acab-67a142b61ffa NVIDIA 1000 0}]]
```



failed schedule logs
```bash

I0110 09:21:00.386970     175 scheduler.go:347] "begin schedule filter" pod="vgpu-test-dc87df5b4-24r9c" uuid="d57d8fba-6771-4d79-a727-58d68f3f4104" namespaces="default"
I0110 09:21:00.387047     175 scheduler.go:288] usage: pod vgpu-test-2-67957884fc-ch9tp assigned tesla [[{0 GPU-e290caca-2f0c-9582-acab-67a142b61ffa NVIDIA 1000 0}]]
I0110 09:21:00.387118     175 score.go:204] "fitInDevices" pod="default/vgpu-test-dc87df5b4-24r9c" node="tesla"
I0110 09:21:00.387137     175 score.go:90] "Allocating device for container request" pod="default/vgpu-test-dc87df5b4-24r9c" card request={"Nums":1,"Type":"NVIDIA","Memreq":1000,"MemPercentagereq":101,"Coresreq":100}
I0110 09:21:00.387161     175 score.go:93] "scoring pod" pod="default/vgpu-test-dc87df5b4-24r9c" Memreq=1000 MemPercentagereq=101 Coresreq=100 Nums=1 device index=0 device="GPU-e290caca-2f0c-9582-acab-67a142b61ffa"
I0110 09:21:00.387195     175 score.go:131] "the container wants exclusive access to an entire card, but the card is already in use" pod="default/vgpu-test-dc87df5b4-24r9c" device index=0 device="GPU-e290caca-2f0c-9582-acab-67a142b61ffa" used=1
I0110 09:21:00.387212     175 score.go:211] "calcScore:node not fit pod" pod="default/vgpu-test-dc87df5b4-24r9c" node="tesla"
I0110 09:21:06.557001     175 scheduler.go:159] "nodes device information" node="tesla" nodedevices="GPU-e290caca-2f0c-9582-acab-67a142b61ffa,10,7680,100,NVIDIA-Tesla P4,0,true:"
```