### PR TITLE
install nvidia-vgpu-schduler as default scheduler

### DIFF
--- a/charts/vgpu/templates/scheduler/deployment.yaml
+++ b/charts/vgpu/templates/scheduler/deployment.yaml
@@ -92,3 +92,6 @@ spec:
       {{- if .Values.scheduler.tolerations }}
       tolerations: {{ toYaml .Values.scheduler.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.scheduler.nodeName }}
+      nodeName: {{ .Values.scheduler.nodeName }}
+      {{- end }}

--- a/charts/vgpu/values.yaml
+++ b/charts/vgpu/values.yaml
@@ -31,6 +31,10 @@ global:
   annotations: {}
 
 scheduler:
+  # @param nodeName defines the node name and the nvidia-vgpu-scheduler-scheduler will schedule to the node.
+  # if we install the nvidia-vgpu-scheduler-scheduler as default scheduler, we need to remove the k8s defualt
+  # scheduler pod from the cluster first, we must specified node name to skip the schedule workflow.
+  nodeName: ""
   defaultMem: 0
   defaultCores: 0
   kubeScheduler:


### PR DESCRIPTION
If we install the nvidia-vgpu-scheduler as default scheduler, we need to remove the k8s defualt
scheduler pod from the cluster first, we must specified node name to skip the shcedule workflow.

And use the following helm command to install nvidia-vgpu-scheduler:

```shell
helm install nvidia-vgpu -n nvidia-vgpu  --create-namespaces \
         --set schedulerName=default-scheduler \
         --set scheduler.nodeName=<node_name> \
         --set scheduler.kubeScheduler.image=<kube_scheduler> \
         --set scheduler.kubeScheduler.tag=<kube_scheduler_tag> \
```
