### PR TITLE
fix device-plugin panic

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -173,6 +173,7 @@ func (s *Scheduler) RegisterFromNodeAnnotatons() error {
 								n, err := util.GetNode(val.Name)
 								if err != nil {
 									klog.Errorln("get node failed", err.Error())
+									continue
 								}
 								util.PatchNodeAnnotations(n, tmppat)
 								continue
@@ -188,6 +189,7 @@ func (s *Scheduler) RegisterFromNodeAnnotatons() error {
 					n, err := util.GetNode(val.Name)
 					if err != nil {
 						klog.Errorln("get node failed", err.Error())
+						continue
 					}
 					util.PatchNodeAnnotations(n, tmppat)
 				}


### PR DESCRIPTION
When `util.GetNode(val.Name)` returns an error, a panic will occur.