### PR TITLE
fix: loss of metrics after vdeivce restart

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -141,7 +141,9 @@ func (s *Scheduler) RegisterFromNodeAnnotatons() error {
 			klog.Errorln("nodes list failed", err.Error())
 			return err
 		}
+		nodeNames := []string{}
 		for _, val := range nodes {
+			nodeNames = append(nodeNames, val.Name)
 			for devhandsk, devreg := range device.KnownDevice {
 				_, ok := val.Annotations[devreg]
 				if !ok {
@@ -228,6 +230,11 @@ func (s *Scheduler) RegisterFromNodeAnnotatons() error {
 					klog.Infof("node %v device %s come node info=%v total=%v", val.Name, devhandsk, nodeInfoCopy[devhandsk], s.nodes[val.Name].Devices)
 				}
 			}
+		}
+		_, _, err = s.getNodesUsage(&nodeNames, nil)
+		if err != nil {
+			klog.Errorln("get node usage failed", err.Error())
+			return err
 		}
 		time.Sleep(time.Second * 15)
 	}


### PR DESCRIPTION
Problem description.

After the scheduler component restarts unexpectedly, some metrics are lost, which can only be obtained when the scheduling is triggered.
![image](https://github.com/4paradigm/k8s-vgpu-scheduler/assets/51119718/254ddd02-242d-4c2b-a227-3046f197cbc1)
![image](https://github.com/4paradigm/k8s-vgpu-scheduler/assets/51119718/81ceb3b6-58b5-4eca-8d60-d307dbf3dd95)


Solution
When scheduler starts, all node information is obtained and injected into scheduler object

The test results are as follows


![image](https://github.com/4paradigm/k8s-vgpu-scheduler/assets/51119718/d1fc817c-fc1b-4f4e-b5cb-7d2cf82e1405)
