### PR TITLE
add metrics bind address flag for scheduler

### DIFF
--- a/charts/vgpu/templates/scheduler/deployment.yaml
+++ b/charts/vgpu/templates/scheduler/deployment.yaml
@@ -63,6 +63,7 @@ spec:
             - --cert_file=/tls/tls.crt
             - --key_file=/tls/tls.key
             - --scheduler-name={{ .Values.schedulerName }}
+            - --metrics-bind-address={{ .Values.scheduler.metricsBindAddress }}
             - --default-mem={{ .Values.scheduler.defaultMem }}
             - --default-cores={{ .Values.scheduler.defaultCores }}
             {{- range .Values.scheduler.extender.extraArgs }}

--- a/charts/vgpu/values.yaml
+++ b/charts/vgpu/values.yaml
@@ -37,6 +37,7 @@ scheduler:
   nodeName: ""
   defaultMem: 0
   defaultCores: 0
+  metricsBindAddress: ":9395"
   kubeScheduler:
     imageTag: "v1.20.0"
     image: registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -55,6 +55,7 @@ func init() {
 	rootCmd.Flags().StringVar(&config.SchedulerName, "scheduler-name", "", "the name to be added to pod.spec.schedulerName if not empty")
 	rootCmd.Flags().Int32Var(&config.DefaultMem, "default-mem", 0, "default gpu device memory to allocate")
 	rootCmd.Flags().Int32Var(&config.DefaultCores, "default-cores", 0, "default gpu core percentage to allocate")
+	rootCmd.Flags().StringVar(&config.MetricsBindAddress, "metrics-bind-address", ":9395", "The TCP address that the scheduler should bind to for serving prometheus metrics(e.g. 127.0.0.1:9395, :9395)")
 	rootCmd.PersistentFlags().AddGoFlagSet(device.GlobalFlagSet())
 	rootCmd.AddCommand(version.VersionCmd)
 	rootCmd.Flags().AddGoFlagSet(util.InitKlogFlags())
@@ -67,7 +68,7 @@ func start() {
 
 	// start monitor metrics
 	go sher.RegisterFromNodeAnnotatons()
-	go initmetrics()
+	go initmetrics(config.MetricsBindAddress)
 
 	// start http server
 	router := httprouter.New()

--- a/cmd/scheduler/metrics.go
+++ b/cmd/scheduler/metrics.go
@@ -221,7 +221,7 @@ func NewClusterManager(zone string, reg prometheus.Registerer) *ClusterManager {
 	return c
 }
 
-func initmetrics() {
+func initmetrics(bindAddress string) {
 	// Since we are dealing with custom Collector implementations, it might
 	// be a good idea to try it out with a pedantic registry.
 	klog.Infof("Initializing metrics for scheduler")
@@ -239,5 +239,5 @@ func initmetrics() {
 	//)
 
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	log.Fatal(http.ListenAndServe(":9395", nil))
+	log.Fatal(http.ListenAndServe(bindAddress, nil))
 }

--- a/pkg/scheduler/config/config.go
+++ b/pkg/scheduler/config/config.go
@@ -17,8 +17,9 @@
 package config
 
 var (
-	HttpBind      string
-	SchedulerName string
-	DefaultMem    int32
-	DefaultCores  int32
+	HttpBind           string
+	SchedulerName      string
+	DefaultMem         int32
+	DefaultCores       int32
+	MetricsBindAddress string
 )


### PR DESCRIPTION
Why do we need the flage?
The metrics port is confilct with vGPU monitor if we deploy the scheduler with `HostNetwork` mode.
In the scenario, we want to deploy scheduler with k8s native scheduler in one static pod with `HostNetwork` mode. but the  vGPU monitor is same port with scheduler.
