### PR TITLE
support manual config MutatingWebhookConfiguration failurePolicy

### DIFF
--- a/charts/vgpu/templates/scheduler/webhook.yaml
+++ b/charts/vgpu/templates/scheduler/webhook.yaml
@@ -15,7 +15,7 @@ webhooks:
         path: /webhook
         port: {{ .Values.scheduler.service.httpPort }}
       {{- end }}
-    failurePolicy: Fail
+    failurePolicy: {{ .Values.scheduler.mutatingWebhookConfiguration.failurePolicy }}
     matchPolicy: Equivalent
     name: vgpu.4pd.io
     namespaceSelector:

--- a/charts/vgpu/values.yaml
+++ b/charts/vgpu/values.yaml
@@ -76,7 +76,8 @@ scheduler:
     nodeSelector: {}
     tolerations: []
     runAsUser: 2000
-
+  mutatingWebhookConfiguration:
+    failurePolicy: Ignore
   service:
     httpPort: 443
     schedulerPort: 31998


### PR DESCRIPTION
fix #83

/kind feature

Add helm values parameter to provide users with the ability to set MutatingWebhookConfiguration failurePolicy. The default value is Ignore,this feature can solve the problem that when the nvidia-vgpu-webhook service is unavailable, the creation and restart of K8s system services (for example: calico cni) will not be affected.


